### PR TITLE
Temporarily turn off wayland support

### DIFF
--- a/com.pot_app.pot.yml
+++ b/com.pot_app.pot.yml
@@ -8,7 +8,7 @@ rename-desktop-file: pot.desktop
 
 finish-args:
   - --socket=x11
-  - --socket=wayland
+  # - --socket=wayland
   - --socket=pulseaudio
   - --share=ipc
   - --share=network


### PR DESCRIPTION
In the latest version of pot, the window & font size is abnormal when running under native Wayland. Turn off Wayland temporarily to solve this issue.